### PR TITLE
Fix CORS error for Netlify frontend

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,7 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->prepend(\Illuminate\Http\Middleware\HandleCors::class);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | CORS Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you can configure the settings for Cross-Origin Resource Sharing
+    | or "CORS". This determines which origins are allowed to access your
+    | resources.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['api/*'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => ['https://asistenciagob.netlify.app'],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => true,
+
+];


### PR DESCRIPTION
This commit resolves the Cross-Origin Resource Sharing (CORS) error that occurred when making requests from the Netlify-hosted frontend (`https://asistenciagob.netlify.app`) to the Laravel backend.

The solution involves two main changes:
1.  A `config/cors.php` file was created to define the CORS policy, specifically allowing the frontend's origin and enabling credential support.
2.  The `HandleCors` middleware was registered in `bootstrap/app.php` to ensure the CORS policy is applied to all incoming API requests.

These changes correctly configure the Laravel application to handle cross-origin requests from the specified frontend.